### PR TITLE
Add bounding box costmap converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ generate_dynamic_reconfigure_options(
   cfg/dynamic_reconfigure/CostmapToLinesDBSMCCH.cfg
   cfg/dynamic_reconfigure/CostmapToLinesDBSRANSAC.cfg
   cfg/dynamic_reconfigure/CostmapToDynamicObstacles.cfg
+  cfg/dynamic_reconfigure/CostmapToBoundingBox.cfg
 )
 
 ###################################
@@ -147,10 +148,11 @@ include_directories(
 )
 
 ## Declare a cpp library
-add_library(costmap_converter   src/costmap_to_polygons.cpp 
+add_library(costmap_converter   src/costmap_to_polygons.cpp
                                 src/costmap_to_polygons_concave.cpp
                                 src/costmap_to_lines_convex_hull.cpp
                                 src/costmap_to_lines_ransac.cpp
+                                src/costmap_to_bounding_box.cpp
                                 src/costmap_to_dynamic_obstacles/costmap_to_dynamic_obstacles.cpp
                                 src/costmap_to_dynamic_obstacles/background_subtractor.cpp
                                 src/costmap_to_dynamic_obstacles/blob_detector.cpp

--- a/cfg/dynamic_reconfigure/CostmapToBoundingBox.cfg
+++ b/cfg/dynamic_reconfigure/CostmapToBoundingBox.cfg
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# For integers and doubles:
+#       Name                    Type      Reconfiguration level
+#       Description
+#       Default  Min  Max
+
+
+gen.add("cluster_max_distance", double_t, 0,
+	"Parameter for DB_Scan, maximum distance to neighbors [m]",
+	0.4, 0.0, 10.0)
+
+gen.add("cluster_min_pts", int_t, 0,
+	"Parameter for DB_Scan: minimum number of points that define a cluster",
+	2, 1, 20)
+
+gen.add("cluster_max_pts", int_t, 0,
+  "Parameter for DB_Scan: maximum number of points that define a cluster (limit cluster size to avoid large L- and U-shapes)",
+  30, 2, 200)
+
+gen.add("convex_hull_min_pt_separation",   double_t,   0,
+	"Clear keypoints of the convex polygon that are close to each other [distance in meters] (0: keep all)",
+	0.1, 0.0, 10.0)
+
+exit(gen.generate("costmap_converter", "standalone_converter", "CostmapToBoundingBox"))

--- a/cfg/dynamic_reconfigure/CostmapToBoundingBox.cfg
+++ b/cfg/dynamic_reconfigure/CostmapToBoundingBox.cfg
@@ -22,8 +22,8 @@ gen.add("cluster_max_pts", int_t, 0,
   "Parameter for DB_Scan: maximum number of points that define a cluster (limit cluster size to avoid large L- and U-shapes)",
   30, 2, 200)
 
-gen.add("convex_hull_min_pt_separation",   double_t,   0,
-	"Clear keypoints of the convex polygon that are close to each other [distance in meters] (0: keep all)",
-	0.1, 0.0, 10.0)
+gen.add("track_unknown_space", bool_t, 0,
+	"Track unknown space (true) or not (false)",
+	False)
 
 exit(gen.generate("costmap_converter", "standalone_converter", "CostmapToBoundingBox"))

--- a/include/costmap_converter/costmap_to_bounding_box.h
+++ b/include/costmap_converter/costmap_to_bounding_box.h
@@ -1,0 +1,77 @@
+#ifndef COSTMAP_TO_BOUNDING_BOX_H_
+#define COSTMAP_TO_BOUNDING_BOX_H_
+
+#include <costmap_converter/costmap_converter_interface.h>
+#include <costmap_converter/costmap_to_polygons.h>
+#include <costmap_converter/misc.h>
+#include <costmap_converter/CostmapToBoundingBoxConfig.h>
+
+namespace costmap_converter
+{
+
+/**
+ * @class CostmapToBoundingBox
+ * @brief This class converts the costmap_2d into a set bounding boxes
+ *
+ * The conversion is performed in two stages:
+ * 1. Clusters in the costmap are collected using the DBSCAN Algorithm (https://en.wikipedia.org/wiki/DBSCAN)
+ *    Reference: Ester, Martin; Kriegel, Hans-Peter; Sander, Jörg; Xu, Xiaowei,
+ *               A density-based algorithm for discovering clusters in large spatial databases with noise.
+ *               Proceedings of the Second International Conference on Knowledge Discovery and Data Mining. AAAI Press.
+ * 1996. pp. 226–231. ISBN 1-57735-004-9.
+ *
+ * 2. Instead of computing the convex hull of each cluster, a bounding box is computed.
+ *
+ * The output is a container of polygons (RECTANGLES bounding boxes)
+ */
+class CostmapToBoundingBox : public CostmapToPolygonsDBSMCCH
+{
+private:
+  static constexpr auto LOGNAME = "CostmapToBoundingBox";
+
+public:
+  /**
+   * @brief Constructor
+   */
+  CostmapToBoundingBox();
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~CostmapToBoundingBox();
+
+  /**
+   * @brief Initialize the plugin
+   * @param nh Nodehandle that defines the namespace for parameters
+   */
+  virtual void initialize(ros::NodeHandle nh);
+
+  /**
+   * @brief This method performs the actual work (conversion of the costmap to bounding box)
+   */
+  virtual void compute();
+
+private:
+  /**
+   * @brief Callback for the dynamic_reconfigure node.
+   *
+   * This callback allows to modify parameters dynamically at runtime without restarting the node
+   * @param config Reference to the dynamic reconfigure config
+   * @param level Dynamic reconfigure level
+   */
+  void reconfigureCB(CostmapToBoundingBoxConfig& config, uint32_t level);
+
+  /**
+   * @brief Computes the bounding box of a cluster of points (keypoints) and stores it in a polygon message
+   * @param cluster List of keypoints that should be converted into a polygon
+   * @param[out] polygon The resulting bounding box
+   */
+  void bbox(std::vector<KeyPoint>& cluster, geometry_msgs::Polygon& polygon);
+
+  dynamic_reconfigure::Server<CostmapToBoundingBoxConfig>* dynamic_recfg_;  //!< Dynamic reconfigure server to allow
+                                                                            //!< config modifications at runtime
+};
+
+}  // namespace costmap_converter
+
+#endif /* COSTMAP_TO_BOUNDING_BOX_H_ */

--- a/include/costmap_converter/costmap_to_polygons.h
+++ b/include/costmap_converter/costmap_to_polygons.h
@@ -308,6 +308,7 @@ class CostmapToPolygonsDBSMCCH : public BaseCostmapToPolygons
 
     Parameters parameter_;          //< active parameters throughout computation
     Parameters parameter_buffered_; //< the buffered parameters that are offered to dynamic reconfigure
+    double costmap_resolution_;     //< resolution of the costmap [m/cell]
     boost::mutex parameter_mutex_;  //!< Mutex that keeps track about the ownership of the shared polygon instance
    
   private:

--- a/plugins.xml
+++ b/plugins.xml
@@ -34,5 +34,11 @@
       This class detects and tracks obstacles from a sequence of costmaps. 
   </description>
   </class>
-  
+
+  <class type="costmap_converter::CostmapToBoundingBox" base_class_type="costmap_converter::BaseCostmapToPolygons">
+  <description>
+      This class converts costmap2d obstacles into a vector of bounding boxes (rectangles)
+  </description>
+  </class>
+
 </library>

--- a/src/costmap_to_bounding_box.cpp
+++ b/src/costmap_to_bounding_box.cpp
@@ -25,8 +25,7 @@ void CostmapToBoundingBox::initialize(ros::NodeHandle nh)
   nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
   nh.param("cluster_min_pts", parameter_.min_pts_, 2);
   nh.param("cluster_max_pts", parameter_.max_pts_, 30);
-  // convex hull (only necessary if outlier filtering is enabled)
-  nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
+  nh.param("track_unknown_space", parameter_.track_unknown_space_, false);
   parameter_buffered_ = parameter_;
 
   // setup dynamic reconfigure
@@ -99,7 +98,7 @@ void CostmapToBoundingBox::reconfigureCB(CostmapToBoundingBoxConfig& config, uin
   parameter_buffered_.max_distance_ = config.cluster_max_distance;
   parameter_buffered_.min_pts_ = config.cluster_min_pts;
   parameter_buffered_.max_pts_ = config.cluster_max_pts;
-  parameter_buffered_.min_keypoint_separation_ = config.cluster_min_pts;
+  parameter_buffered_.track_unknown_space_ = config.track_unknown_space;
 }
 
 }  // end namespace costmap_converter

--- a/src/costmap_to_bounding_box.cpp
+++ b/src/costmap_to_bounding_box.cpp
@@ -1,0 +1,105 @@
+#include <costmap_converter/costmap_to_bounding_box.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(costmap_converter::CostmapToBoundingBox, costmap_converter::BaseCostmapToPolygons)
+
+namespace costmap_converter
+{
+
+CostmapToBoundingBox::CostmapToBoundingBox() : CostmapToPolygonsDBSMCCH()
+{
+  dynamic_recfg_ = NULL;
+}
+
+CostmapToBoundingBox::~CostmapToBoundingBox()
+{
+  if (dynamic_recfg_ != NULL)
+    delete dynamic_recfg_;
+}
+
+void CostmapToBoundingBox::initialize(ros::NodeHandle nh)
+{
+  // DB SCAN
+  nh.param("cluster_max_distance", parameter_.max_distance_, 0.4);
+  nh.param("cluster_min_pts", parameter_.min_pts_, 2);
+  nh.param("cluster_max_pts", parameter_.max_pts_, 30);
+  // convex hull (only necessary if outlier filtering is enabled)
+  nh.param("convex_hull_min_pt_separation", parameter_.min_keypoint_separation_, 0.1);
+  parameter_buffered_ = parameter_;
+
+  // setup dynamic reconfigure
+  dynamic_recfg_ = new dynamic_reconfigure::Server<CostmapToBoundingBoxConfig>(nh);
+  dynamic_reconfigure::Server<CostmapToBoundingBoxConfig>::CallbackType cb =
+      boost::bind(&CostmapToBoundingBox::reconfigureCB, this, _1, _2);
+  dynamic_recfg_->setCallback(cb);
+}
+
+void CostmapToBoundingBox::compute()
+{
+  std::vector<std::vector<KeyPoint> > clusters;
+  dbScan(clusters);
+
+  // Create new polygon container
+  PolygonContainerPtr polygons(new std::vector<geometry_msgs::Polygon>());
+
+  // add bbox to polygon container
+  for (std::size_t i = 1; i < clusters.size(); ++i)  // skip first cluster, since it is just noise
+  {
+    polygons->push_back(geometry_msgs::Polygon());
+    bbox(clusters[i], polygons->back());
+  }
+
+  // add our non-cluster points to the polygon container (as single points)
+  if (!clusters.empty())
+  {
+    for (std::size_t i = 0; i < clusters.front().size(); ++i)
+    {
+      polygons->push_back(geometry_msgs::Polygon());
+      convertPointToPolygon(clusters.front()[i], polygons->back());
+    }
+  }
+
+  // replace shared polygon container
+  updatePolygonContainer(polygons);
+}
+
+void CostmapToBoundingBox::bbox(std::vector<KeyPoint>& cluster, geometry_msgs::Polygon& polygon)
+{
+  double min_x = std::numeric_limits<double>::max();
+  double min_y = std::numeric_limits<double>::max();
+  double max_x = -std::numeric_limits<double>::max();
+  double max_y = -std::numeric_limits<double>::max();
+  for (const auto& keypoint : cluster)
+  {
+    min_x = std::min(min_x, keypoint.x);
+    min_y = std::min(min_y, keypoint.y);
+    max_x = std::max(max_x, keypoint.x);
+    max_y = std::max(max_y, keypoint.y);
+  }
+
+  polygon.points.resize(4);
+  polygon.points[0].x = min_x - costmap_resolution_ / 2;
+  polygon.points[0].y = min_y - costmap_resolution_ / 2;
+
+  polygon.points[1].x = min_x - costmap_resolution_ / 2;
+  polygon.points[1].y = max_y + costmap_resolution_ / 2;
+
+  polygon.points[2].x = max_x + costmap_resolution_ / 2;
+  polygon.points[2].y = max_y + costmap_resolution_ / 2;
+
+  polygon.points[3].x = max_x + costmap_resolution_ / 2;
+  polygon.points[3].y = min_y - costmap_resolution_ / 2;
+}
+
+void CostmapToBoundingBox::reconfigureCB(CostmapToBoundingBoxConfig& config, uint32_t level)
+{
+  boost::mutex::scoped_lock lock(parameter_mutex_);
+  parameter_buffered_.max_distance_ = config.cluster_max_distance;
+  parameter_buffered_.min_pts_ = config.cluster_min_pts;
+  parameter_buffered_.max_pts_ = config.cluster_max_pts;
+  parameter_buffered_.min_keypoint_separation_ = config.cluster_min_pts;
+}
+
+}  // end namespace costmap_converter

--- a/src/costmap_to_polygons.cpp
+++ b/src/costmap_to_polygons.cpp
@@ -179,6 +179,7 @@ void CostmapToPolygonsDBSMCCH::setCostmap2D(costmap_2d::Costmap2D *costmap)
 void CostmapToPolygonsDBSMCCH::updateCostmap2D()
 {
       occupied_cells_.clear();
+      costmap_resolution_ = costmap_->getResolution();
       
       if (!costmap_->getMutex())
       {

--- a/src/costmap_to_polygons.cpp
+++ b/src/costmap_to_polygons.cpp
@@ -179,7 +179,6 @@ void CostmapToPolygonsDBSMCCH::setCostmap2D(costmap_2d::Costmap2D *costmap)
 void CostmapToPolygonsDBSMCCH::updateCostmap2D()
 {
       occupied_cells_.clear();
-      costmap_resolution_ = costmap_->getResolution();
       
       if (!costmap_->getMutex())
       {
@@ -194,6 +193,8 @@ void CostmapToPolygonsDBSMCCH::updateCostmap2D()
       
       costmap_2d::Costmap2D::mutex_t::scoped_lock lock(*costmap_->getMutex());
 
+      costmap_resolution_ = costmap_->getResolution();
+      
       // allocate neighbor lookup
       int cells_x = int(costmap_->getSizeInMetersX() / parameter_.max_distance_) + 1;
       int cells_y = int(costmap_->getSizeInMetersY() / parameter_.max_distance_) + 1;


### PR DESCRIPTION
# Description
[AB#17198](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/17198)

Instead of creating polygons, it creates bounding boxes.
Not very useful in costmap application, unless you want to navigate very conservative.
But it is useful as a filter for simple obstacle detection.

In our case, it is a pre-processing for ODR

![Screenshot from 2024-09-10 16-32-05](https://github.com/user-attachments/assets/325bef6a-ced1-4c5b-82b7-42ba5820b3e2)
