### PR TITLE
Fix costmap converter origin in update loop

### DIFF
--- a/src/costmap_converter_node.cpp
+++ b/src/costmap_converter_node.cpp
@@ -147,12 +147,14 @@ public:
 
   void costmapUpdateCallback(const map_msgs::OccupancyGridUpdateConstPtr& update)
   {
+    int origin_x = update->x;
+    int origin_y = update->y;
     unsigned int di = 0;
     for (unsigned int y = 0; y < update->height ; ++y)
     {
       for (unsigned int x = 0; x < update->width ; ++x)
       {
-        map_.setCost(x, y, update->data[di++] >= occupied_min_value_ ? 255 : 0 );
+        map_.setCost(x + origin_x, y + origin_y, update->data[di++] >= occupied_min_value_ ? 255 : 0);
       }
     }
 


### PR DESCRIPTION
The node does not take into account the origin of the map in the `costmap_update` callback

Before:


https://github.com/user-attachments/assets/b7b1d4a3-dac2-4daa-acac-528b9512221c

After:


https://github.com/user-attachments/assets/32925091-40b3-440f-b47d-0923d9d3c702

